### PR TITLE
Fix General Hospital (and possibly other shows)

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -51,10 +51,11 @@ def Season(title, showId):
 	oc = ObjectContainer(title2=title)
 
 	for season in HTML.ElementFromURL(SEASONS % showId, cacheTime=CACHE_1DAY).xpath('//a'):
-		title = season.text
-		season = title.rsplit(' ', 1)[1]
-
-		oc.add(DirectoryObject(key=Callback(Episodes, title=title, showId=showId, season=season), title=title))
+		seasonid = season.get('seasonid')
+		if not seasonid:
+			title = season.text
+			seasonid = title.rsplit(' ', 1)[1]
+		oc.add(DirectoryObject(key=Callback(Episodes, title=title, showId=showId, season=seasonid), title=title))
 
 	return oc
 


### PR DESCRIPTION
Some shows have a seasonid attribute in the season list page which should be used to grab episodes.  If no such attribute exists, we can default to using the text as it does today.
