### PR TITLE
Allow OSX Safari users to use the channel with a non OSX PMS

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -21,7 +21,7 @@ def MainMenu():
 
 	oc = ObjectContainer()
 
-	if not Client.Platform in ('Android', 'iOS', 'Roku') and not (Client.Platform == 'Safari' and Platform.OS == 'MacOSX'):
+	if not Client.Platform in ('Android', 'iOS', 'Roku') and not (Client.Platform == 'Safari' and Request.Headers['X-Plex-Device'] == 'OSX'):
 		oc.header = 'Not supported'
 		oc.message = 'This channel is not supported on %s' % (Client.Platform if Client.Platform is not None else 'this client')
 		return oc


### PR DESCRIPTION
https://forums.plex.tv/index.php/topic/132080-abc-and-nbc-channel-not-supported-in-browser/#entry810758